### PR TITLE
Fixed the autostop/autoscope [bind check added]

### DIFF
--- a/NEPS/Hacks/Aimbot.cpp
+++ b/NEPS/Hacks/Aimbot.cpp
@@ -122,6 +122,8 @@ void Aimbot::predictPeek(UserCmd *cmd) noexcept
 		if (const auto it = std::find_if(records.rbegin(), records.rend(), [](const Record &record) noexcept { return Backtrack::valid(record.simulationTime); }); it != records.rend())
 			damage = std::max(damage, Helpers::findDamage(localPlayer.get(), entity, occludedBacktrack, cfg.friendlyFire, predictionFactor, &(*it)));
 
+		if (static Helpers::KeyBindState flag; !flag[cfg.bind]) return;
+		
 		if (damage > 0 && (!cfg.visibleOnly || !occluded || !occludedBacktrack))
 		{
 			if (cfg.autoScope && !localPlayer->isScoped() && activeWeapon->isSniperRifle())


### PR DESCRIPTION
Fixed the autostop/autoscope being triggered even tho you weren't "using" aimbot.
So bind check was added to fix this issue.
Credits for this fix and for bringing this issue up go to "swr#5647" (On our discord server).