### PR TITLE
Fix crashing bug

### DIFF
--- a/NEPS/GameData.cpp
+++ b/NEPS/GameData.cpp
@@ -315,7 +315,8 @@ void LocalPlayerData::update() noexcept
 
 		origin = obs->getAbsOrigin();
 		velocity = obs->velocity();
-		eyePosition = obs->getEyePosition();
+		if (obs->isPlayer())
+			eyePosition = obs->getEyePosition();
 		// Calling Entity::getAimPunch() not on the local player sometimes causes crashing
 		//aimPunch = eyePosition + Vector::fromAngle(interfaces->engine->getViewAngles() + obs->getAimPunch()) * 1000;
 


### PR DESCRIPTION
We all know that when all Terrorists die and manage to plant the bomb, they all begin to spectate the bomb. When that would happen, it would cause the cheat to read the eye angles of the bomb, which would just result in an error and a instant crash. This should add a check to prevent this bug from occurring again.