### PR TITLE
Add Playerlist and cheat filtering feature

### DIFF
--- a/NEPS/Config.cpp
+++ b/NEPS/Config.cpp
@@ -621,6 +621,10 @@ static void from_json(const json &j, Config::Sound &s)
 static void from_json(const json& j, Config::Players& p)
 {
 	read(j, "Enabled", p.enabled);
+	read(j, "Filter aim", p.filterAim);
+	read(j, "Filter ESP", p.filterESP);
+	read(j, "Filter chams", p.filterChams);
+	read(j, "Filter glow", p.filterGlow);
 }
 
 static void from_json(const json &j, Config::Style &s)
@@ -1156,6 +1160,10 @@ static void to_json(json& j, const Config::Players& o)
 {
 	const Config::Players dummy;
 	WRITE("Enabled", enabled);
+	WRITE("Filter aim", filterAim);
+	WRITE("Filter ESP", filterESP);
+	WRITE("Filter chams", filterChams);
+	WRITE("Filter glow", filterGlow);
 }
 
 static void to_json(json &j, const Config::Misc::PurchaseList &o, const Config::Misc::PurchaseList &dummy = {})

--- a/NEPS/Config.cpp
+++ b/NEPS/Config.cpp
@@ -618,6 +618,11 @@ static void from_json(const json &j, Config::Sound &s)
 	read<value_t::string>(j, "Custom death sound", s.customDeathSound);
 }
 
+static void from_json(const json& j, Config::Players& p)
+{
+	read(j, "Enabled", p.enabled);
+}
+
 static void from_json(const json &j, Config::Style &s)
 {
 	read(j, "Menu style", s.menuStyle);
@@ -818,6 +823,7 @@ bool Config::load(const char8_t *name, bool incremental) noexcept
 	read<value_t::object>(j, "Visuals", visuals);
 	read(j, "Skin changer", skinChanger);
 	read<value_t::object>(j, "Sound", sound);
+	read<value_t::object>(j, "Players", players);
 	read<value_t::object>(j, "Style", style);
 	read<value_t::object>(j, "Misc", misc);
 	read<value_t::object>(j, "Exploits", exploits);
@@ -1144,6 +1150,12 @@ static void to_json(json &j, const Config::Sound &o)
 	WRITE("Custom hit sound", customHitSound);
 	WRITE("Custom kill sound", customKillSound);
 	WRITE("Custom death sound", customDeathSound);
+}
+
+static void to_json(json& j, const Config::Players& o)
+{
+	const Config::Players dummy;
+	WRITE("Enabled", enabled);
 }
 
 static void to_json(json &j, const Config::Misc::PurchaseList &o, const Config::Misc::PurchaseList &dummy = {})
@@ -1498,6 +1510,7 @@ void Config::save(size_t id) const noexcept
 		j["Chams"] = chams;
 		j["ESP"] = esp;
 		j["Sound"] = sound;
+		j["Players"] = players;
 		j["Visuals"] = visuals;
 		j["Misc"] = misc;
 		j["Style"] = style;
@@ -1546,6 +1559,7 @@ void Config::reset() noexcept
 	visuals = {};
 	skinChanger = {};
 	sound = {};
+	players = {};
 	style = {};
 	exploits = {};
 	griefing = {};

--- a/NEPS/Config.h
+++ b/NEPS/Config.h
@@ -310,6 +310,10 @@ public:
 
 	struct Players {
 		bool enabled = false;
+		bool filterAim = false;
+		bool filterESP = false;
+		bool filterChams = false;
+		bool filterGlow = false;
 	} players;
 
 	struct Style

--- a/NEPS/Config.h
+++ b/NEPS/Config.h
@@ -308,6 +308,10 @@ public:
 		std::string customDeathSound;
 	} sound;
 
+	struct Players {
+		bool enabled = false;
+	} players;
+
 	struct Style
 	{
 		int menuStyle = 0;

--- a/NEPS/GUI.cpp
+++ b/NEPS/GUI.cpp
@@ -135,6 +135,7 @@ void GUI::render() noexcept
 		renderStyleWindow();
 		renderExploitsWindow();
 		renderGriefingWindow();
+		renderPlayersWindow();
 		renderMovementWindow();
 		renderMiscWindow();
 		renderConfigWindow();
@@ -254,6 +255,11 @@ void GUI::renderGuiStyle2() noexcept
 			renderGriefingWindow(true);
 			ImGui::EndTabItem();
 		}
+		if (ImGui::BeginTabItem("Players"))
+		{
+			renderPlayersWindow(true);
+			ImGui::EndTabItem();
+		}
 		if (ImGui::BeginTabItem("Movement"))
 		{
 			renderMovementWindow(true);
@@ -311,6 +317,7 @@ void GUI::renderMenuBar() noexcept
 		menuBarItem("Visuals", window.visuals);
 		menuBarItem("Skin changer", window.skinChanger);
 		menuBarItem("Sound", window.sound);
+		menuBarItem("Players", window.players);
 		menuBarItem("Griefing", window.griefing);
 		menuBarItem("Exploits", window.exploits);
 		menuBarItem("Movement", window.movement);
@@ -367,6 +374,53 @@ void GUI::renderMenuBar() noexcept
 
 		ImGui::EndMainMenuBar();
 	}
+}
+
+void GUI::renderPlayersWindow(bool contentOnly) noexcept {
+	if (!contentOnly)
+	{
+		if (!window.players)
+			return;
+		ImGui::Begin("Players", &window.antiAim, windowFlags);
+	}
+
+	ImGui::Checkbox("Enabled", &config->players.enabled);
+
+	ImGui::Separator();
+
+	constexpr std::array testItems = { "Joe", "Player 1", "Cum Guzzler", "c*ntDestroyer" };
+	static std::size_t currentItem;
+
+	if (ImGui::BeginListBox("##list", { 70, 120 }))
+	{
+		for (std::size_t i = 0; i < testItems.size(); ++i)
+		{
+			if (ImGui::Selectable(testItems[i], currentItem == i))
+				currentItem = i;
+
+			if (ImGui::BeginDragDropSource())
+			{
+				// todo: replace this with player settings
+				ImGui::SetDragDropPayload("PlayerCFG", &config->antiAim[testItems[i]], sizeof(Config::AntiAim), ImGuiCond_Once);
+				DRAGNDROP_HINT("PlayerCFG")
+					ImGui::EndDragDropSource();
+			}
+
+			if (ImGui::BeginDragDropTarget())
+			{
+				if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("PlayerCFG"))
+				{
+					//const auto& data = *(Config::AntiAim*)payload->Data;
+					//config->antiAim[testItems[i]] = data;
+				}
+
+				ImGui::EndDragDropTarget();
+			}
+		}
+		ImGui::EndListBox();
+	}
+
+	ImGui::SameLine();
 }
 
 void GUI::renderAimbotWindow(bool contentOnly) noexcept

--- a/NEPS/GUI.h
+++ b/NEPS/GUI.h
@@ -21,6 +21,7 @@ private:
 	void renderContextMenu() noexcept;
 	void renderMenuBar() noexcept;
 	void renderDebugWindow() noexcept;
+	void renderPlayersWindow(bool contentOnly = false) noexcept;
 	void renderAimbotWindow(bool contentOnly = false) noexcept;
 	void renderAntiAimWindow(bool contentOnly = false) noexcept;
 	void renderTriggerbotWindow(bool contentOnly = false) noexcept;
@@ -50,6 +51,7 @@ private:
 		bool visuals = false;
 		bool skinChanger = false;
 		bool sound = false;
+		bool players = false;
 		bool griefing = false;
 		bool exploits = false;
 		bool movement = false;

--- a/NEPS/Hacks/Aimbot.cpp
+++ b/NEPS/Hacks/Aimbot.cpp
@@ -1,6 +1,7 @@
 #include "Aimbot.h"
 #include "Misc.h"
 #include "Backtrack.h"
+#include "Players.h"
 
 #include "../Config.h"
 #include "../Interfaces.h"
@@ -105,6 +106,10 @@ void Aimbot::predictPeek(UserCmd *cmd) noexcept
 		if (!entity || entity == localPlayer.get() || entity->isDormant() || !entity->isAlive() || entity->gunGameImmunity())
 			continue;
 
+		// if the players feature and aim filter is enabled, and the player was not flagged as a target, then don't target them
+		if (config->players.enabled && config->players.filterAim && !Players::players[i].flagged)
+			continue;
+
 		const auto enemy = localPlayer->isOtherEnemy(entity);
 		if (!cfg.friendlyFire && !enemy)
 			continue;
@@ -182,6 +187,10 @@ void chooseTarget(UserCmd *cmd) noexcept
 		auto entity = interfaces->entityList->getEntity(i);
 
 		if (!entity || entity == localPlayer.get() || entity->isDormant() || !entity->isAlive() || entity->gunGameImmunity())
+			continue;
+
+		// if the players feature and aim filter is enabled, and the player was not flagged as a target, then don't target them
+		if (config->players.enabled && config->players.filterAim && !Players::players[i].flagged)
 			continue;
 
 		const auto enemy = localPlayer->isOtherEnemy(entity);

--- a/NEPS/Hacks/Chams.cpp
+++ b/NEPS/Hacks/Chams.cpp
@@ -3,6 +3,7 @@
 #include "Chams.h"
 #include "Animations.h"
 #include "Backtrack.h"
+#include "Players.h"
 
 #include "../Config.h"
 #include "../GameData.h"
@@ -161,6 +162,9 @@ void Chams::renderPlayer(Entity* player) noexcept
 		if (!appliedChams) hooks->modelRender.callOriginal<void, 21>(ctx, state, info, customBoneToWorld);
     } else if (localPlayer->isOtherEnemy(player))
 	{
+		// if the players feature and aim filter is enabled, and the player was not flagged as a target, then don't target them
+		if (config->players.enabled && config->players.filterChams && !Players::players[player->index()].flagged)
+			return;
 		if (config->backtrack.enabled)
 		{
 			const auto &records = Backtrack::getRecords(player->index());

--- a/NEPS/Hacks/Glow.cpp
+++ b/NEPS/Hacks/Glow.cpp
@@ -1,5 +1,6 @@
 #include "../Config.h"
 #include "Glow.h"
+#include "Players.h"
 #include "../Interfaces.h"
 #include "../Memory.h"
 #include "../SDK/Entity.h"
@@ -24,6 +25,10 @@ void Glow::render() noexcept
 	{
 		const auto entity = interfaces->entityList->getEntity(i);
 		if (!entity || entity->isDormant())
+			continue;
+
+		// if the players feature and aim filter is enabled, and the player was not flagged as a target, then don't target them
+		if (config->players.enabled && config->players.filterGlow && !Players::players[i].flagged)
 			continue;
 
 		switch (entity->getClientClass()->classId)

--- a/NEPS/Hacks/Players.cpp
+++ b/NEPS/Hacks/Players.cpp
@@ -1,5 +1,39 @@
 #include "Players.h"
 
-void Players::updatePlayerList() noexcept {
+#include "../Config.h"
+#include "../Interfaces.h"
+#include "../Memory.h"
+#include "../GameData.h"
 
+#include "../SDK/Entity.h"
+#include "../SDK/EngineTrace.h"
+#include "../SDK/PhysicsSurfaceProps.h"
+#include "../SDK/GlobalVars.h"
+#include "../SDK/UserCmd.h"
+#include "../SDK/WeaponData.h"
+#include "../SDK/WeaponId.h"
+#include "../SDK/StudioRender.h"
+
+#include "../lib/Helpers.hpp"
+
+void Players::updatePlayerList() noexcept {
+	if (!config->players.enabled) return;
+	if (!localPlayer) return;
+    for (int i = 0; i < players.size(); i++) {
+        auto player = &players.at(i);
+
+        if (!player)
+            continue;
+
+        auto entity = interfaces->entityList->getEntity(i);
+        if (!entity || !entity->isPlayer() || entity == localPlayer.get()) {
+            player->invalid = true;
+            player->flagged = false;
+            continue;
+        }
+        else {
+            player->invalid = false;
+            player->name = entity->getPlayerName();
+        }
+    }
 }

--- a/NEPS/Hacks/Players.cpp
+++ b/NEPS/Hacks/Players.cpp
@@ -1,0 +1,5 @@
+#include "Players.h"
+
+void Players::updatePlayerList() noexcept {
+
+}

--- a/NEPS/Hacks/Players.h
+++ b/NEPS/Hacks/Players.h
@@ -1,12 +1,14 @@
 #pragma once
 #include <vector>
 #include <array>
+#include <string>
 
 namespace Players
 {
 	struct PlayerData {
 		bool invalid = true;
 		bool flagged = false;
+		std::string name;
 	};
 
 	void updatePlayerList() noexcept;

--- a/NEPS/Hacks/Players.h
+++ b/NEPS/Hacks/Players.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <array>
+
+namespace Players
+{
+	struct PlayerData {
+		bool invalid = true;
+		bool flagged = false;
+	};
+
+	void updatePlayerList() noexcept;
+
+	inline std::array<PlayerData, 65> players{};
+	inline PlayerData invalidData{};
+}

--- a/NEPS/Hacks/StreamProofESP.cpp
+++ b/NEPS/Hacks/StreamProofESP.cpp
@@ -1,4 +1,5 @@
 #include "StreamProofESP.h"
+#include "Players.h"
 
 #include <shared_lib/imgui/imgui.h>
 #define IMGUI_DEFINE_MATH_OPERATORS
@@ -623,6 +624,10 @@ void StreamProofESP::render() noexcept
 	{
 		if (!player.alive) continue;
 		if (player.handle == GameData::local().observerTargetHandle) continue;
+
+		//// not quite sure how to get the entity index within this context. Kill me please.
+		//if (config->players.enabled && config->players.filterESP && !Players::players[player.index].flagged)
+		//	continue;
 
 		auto &playerConfig = player.enemy ? config->esp.enemies : config->esp.allies;
 

--- a/NEPS/Hooks.cpp
+++ b/NEPS/Hooks.cpp
@@ -22,6 +22,7 @@
 #include "Hacks/Misc.h"
 #include "Hacks/Triggerbot.h"
 #include "Hacks/Visuals.h"
+#include "Hacks/Players.h"
 
 #include "SDK/ClientClass.h"
 #include "SDK/Cvar.h"
@@ -178,6 +179,7 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd *cmd) noexcept
 	memory->globalVars->serverTime(cmd);
 	Misc::changeConVarsTick();
 
+	Players::updatePlayerList();
 	Misc::runChatSpammer();
 	Misc::runReportbot();
 	Misc::antiAfkKick(cmd);

--- a/NEPS/NEPS.vcxproj.filters
+++ b/NEPS/NEPS.vcxproj.filters
@@ -182,6 +182,9 @@
     <ClCompile Include="SDK\CRC.cpp">
       <Filter>SDK</Filter>
     </ClCompile>
+    <ClCompile Include="Hacks\Players.cpp">
+      <Filter>Hacks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GUI.h">
@@ -513,6 +516,9 @@
     </ClInclude>
     <ClInclude Include="SDK\CRC.h">
       <Filter>SDK</Filter>
+    </ClInclude>
+    <ClInclude Include="Hacks\Players.h">
+      <Filter>Hacks</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I have added a fairly simple PlayerList feature which can so far allow you to steal names, or disable aim, chams, or glow for all but "flagged" users.

Currently esp filter does not work as I am not sure how to get entity index from within the context of the esp code. If someone knows how i will fix that.

This is a fairly basic beginning for a playerlist, in the future it could definitely have more features added to it.