### PR TITLE
move check localPlayer to top

### DIFF
--- a/NEPS/Hacks/Animations.cpp
+++ b/NEPS/Hacks/Animations.cpp
@@ -31,14 +31,14 @@ void Animations::getDesyncedBoneMatrices(Matrix3x4 *out) noexcept
 void Animations::localComputeDesync(const UserCmd &cmd, bool sendPacket) noexcept
 {
 	assert(desyncedState);
+	
+	if (!localPlayer || !localPlayer->isAlive()) return;
 
 	auto &poseParams = localPlayer->poseParams();
 	const auto layers = localPlayer->animLayers();
 	if (!desyncedState || !layers)
 		return;
-
-	if (!localPlayer || !localPlayer->isAlive()) return;
-
+	
 	if (!memory->input->isCameraInThirdPerson) return;
 
 	if (static auto spawnTime = 0.0f; !interfaces->engine->isInGame() || spawnTime != localPlayer->spawnTime())


### PR DESCRIPTION
move check localPlayer to top before getting poseParams & animLayers since this make more sense than checking it after reading the layers and poseParams
p/s: I haven't used your things, just reading for learning purposes so idk but this make more sense to me + might avoid some crash if localPlayer was nullptr and you trying to read the data from nullptr?